### PR TITLE
Add support for player health

### DIFF
--- a/src/animation/animate_sprite.rs
+++ b/src/animation/animate_sprite.rs
@@ -53,7 +53,9 @@ fn animate_sprite(
         With<CharacterMarker>,
     >,
 ) {
-    for (transform, indices, mut timer, mut sprite, mut ping_pong, moveable, mut status) in &mut query {
+    for (transform, indices, mut timer, mut sprite, mut ping_pong, moveable, mut status) in
+        &mut query
+    {
         let delta = time.delta();
         let delta_seconds = delta.as_secs_f32();
         timer.0.tick(delta);
@@ -76,7 +78,7 @@ fn animate_sprite(
                         &sprite.index,
                     );
 
-                    if sprite.index == indices.celebrate_end{
+                    if sprite.index == indices.celebrate_end {
                         status.end_celebration();
                     }
                 }

--- a/src/animation/animate_sprite.rs
+++ b/src/animation/animate_sprite.rs
@@ -48,19 +48,19 @@ fn animate_sprite(
             &mut TextureAtlasSprite,
             &mut PingPong,
             &Moveable,
-            &Status,
+            &mut Status,
         ),
         With<CharacterMarker>,
     >,
 ) {
-    for (transform, indices, mut timer, mut sprite, mut ping_pong, moveable, status) in &mut query {
+    for (transform, indices, mut timer, mut sprite, mut ping_pong, moveable, mut status) in &mut query {
         let delta = time.delta();
         let delta_seconds = delta.as_secs_f32();
         timer.0.tick(delta);
 
         // Time for the next frame?
         if timer.0.just_finished() {
-            match status.state {
+            match status.state() {
                 CharacterState::Alive => handle_status_alive(
                     sprite,
                     ping_pong,
@@ -74,7 +74,11 @@ fn animate_sprite(
                     (sprite.index, *ping_pong) = determine_frame_oneshot(
                         indices.celebrate_start..=indices.celebrate_end,
                         &sprite.index,
-                    )
+                    );
+
+                    if sprite.index == indices.celebrate_end{
+                        status.end_celebration();
+                    }
                 }
                 CharacterState::Dead => {
                     // Run death animation once

--- a/src/characters.rs
+++ b/src/characters.rs
@@ -22,7 +22,7 @@ pub(crate) enum Direction {
 /// - `Alive` and able to move
 /// - `Celebrating` completed the level
 /// - `Dead` failed to complete the level
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CharacterState {
     Alive,
     Celebrating,

--- a/src/characters/status.rs
+++ b/src/characters/status.rs
@@ -24,22 +24,22 @@ impl Status {
     }
 
     /// Remove the given number of health points.
-    pub(crate) fn remove_health(&mut self, to_remove: u8){
+    pub(crate) fn remove_health(&mut self, to_remove: u8) {
         self.health -= to_remove;
 
-        if self.health == 0{
+        if self.health == 0 {
             self.state = CharacterState::Dead;
         }
     }
 
     /// Indicate that the character is celebrating.
-    pub(crate) fn celebrate(&mut self){
+    pub(crate) fn celebrate(&mut self) {
         self.state = CharacterState::Celebrating;
     }
 
     /// End the character celebration.
-    pub(crate) fn end_celebration(&mut self){
-        if self.state == CharacterState::Celebrating{
+    pub(crate) fn end_celebration(&mut self) {
+        if self.state == CharacterState::Celebrating {
             self.state = CharacterState::Alive;
         }
     }

--- a/src/characters/status.rs
+++ b/src/characters/status.rs
@@ -2,8 +2,45 @@ use bevy::ecs::component::Component;
 
 use super::CharacterState;
 
-/// Used to store the current [`CharacterState`] of a character.
+/// Used to store the current [`CharacterState`] and health of a character.
 #[derive(Component)]
 pub(crate) struct Status {
-    pub(crate) state: CharacterState,
+    state: CharacterState,
+    health: u8,
+}
+
+impl Status {
+    /// Creates a new [`Status`] with the given health.
+    pub(crate) fn new(health: u8) -> Self {
+        Self {
+            state: CharacterState::Alive,
+            health,
+        }
+    }
+
+    /// Returns the current [`Status`] of the character.
+    pub(crate) fn state(&self) -> CharacterState {
+        self.state
+    }
+
+    /// Remove the given number of health points.
+    pub(crate) fn remove_health(&mut self, to_remove: u8){
+        self.health -= to_remove;
+
+        if self.health == 0{
+            self.state = CharacterState::Dead;
+        }
+    }
+
+    /// Indicate that the character is celebrating.
+    pub(crate) fn celebrate(&mut self){
+        self.state = CharacterState::Celebrating;
+    }
+
+    /// End the character celebration.
+    pub(crate) fn end_celebration(&mut self){
+        if self.state == CharacterState::Celebrating{
+            self.state = CharacterState::Alive;
+        }
+    }
 }

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -109,10 +109,11 @@ fn main_menu_setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Common style for all buttons on the screen
     let button_style = Style {
         width: Val::Percent(50.0),
-        height: Val::Percent(50.0),
+        height: Val::Percent(25.0),
         margin: UiRect::all(Val::Px(2.0)),
         justify_content: JustifyContent::Center,
         align_items: AlignItems::Center,
+        align_self: AlignSelf::End,
         ..default()
     };
     let button_icon_style = Style {
@@ -133,11 +134,9 @@ fn main_menu_setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         .spawn((
             NodeBundle {
                 style: Style {
-                    width: Val::Px(320.),
-                    height: Val::Px(176.),
-                    align_self: AlignSelf::Center,
-                    align_items: AlignItems::Center,
-                    justify_content: JustifyContent::End,
+                    align_self: AlignSelf::Stretch,
+                    align_items: AlignItems::Start,
+                    justify_content: JustifyContent::Center,
                     ..default()
                 },
                 ..default()
@@ -145,31 +144,22 @@ fn main_menu_setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             OnMainMenuScreen,
         ))
         .with_children(|parent| {
+            // Display splash bitmap
+            let splash_image: Handle<Image> = asset_server.load("images/splash.png");
             parent
-                .spawn(NodeBundle {
+                .spawn(ImageBundle {
                     style: Style {
+                        align_self: AlignSelf::End,
+                        width: Val::Px(480.),
+                        height: Val::Px(288.),
+                        justify_content: JustifyContent::SpaceAround,
                         flex_direction: FlexDirection::Column,
-                        align_items: AlignItems::End,
-                        ..default()
+                        ..Default::default()
                     },
-                    background_color: Color::CRIMSON.into(),
+                    image: UiImage::new(splash_image),
                     ..default()
                 })
                 .with_children(|parent| {
-                    // Display spash bitmap
-                    let splash_image: Handle<Image> = asset_server.load("images/splash.png");
-                    parent.spawn(ImageBundle {
-                        style: Style {
-                            position_type: PositionType::Absolute,
-                            align_self: AlignSelf::Center,
-                            align_items: AlignItems::Stretch,
-                            width: Val::Px(320.),
-                            height: Val::Px(176.),
-                            ..Default::default()
-                        },
-                        image: UiImage::new(splash_image),
-                        ..default()
-                    });
                     // Display the game name
                     parent.spawn(
                         TextBundle::from_section(
@@ -182,6 +172,7 @@ fn main_menu_setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         )
                         .with_style(Style {
                             margin: UiRect::all(Val::Px(10.0)),
+                            align_self: AlignSelf::End,
                             ..default()
                         }),
                     );

--- a/src/setup/initial_setup.rs
+++ b/src/setup/initial_setup.rs
@@ -113,9 +113,7 @@ fn setup_player(
                 speed: Speed(1.0),
             },
         },
-        status: Status {
-            state: CharacterState::Alive,
-        },
+        status: Status::new(100),
     });
 }
 


### PR DESCRIPTION
This updates the `Status` component to add a field for player health. This can be decremented and when it reaches zero, the player's state will be set to `CharacterState::Dead`.

As a drive by, this PR also fixes the display of the splash screen so it now fills the screen.